### PR TITLE
Andy/parsed prereqs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v7
         with:
@@ -52,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Build Docker image
         id: docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, andy/parsed-prereqs]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main, andy/parsed-prereqs]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.23"
+
+      - name: Run tests
+        id: test
+        run: |
+          set +e
+          output=$(go test ./... -v -count=1 2>&1)
+          exit_code=$?
+          set -e
+
+          echo "$output"
+
+          passed=$(echo "$output" | grep -c "^--- PASS" || true)
+          failed=$(echo "$output" | grep -c "^--- FAIL" || true)
+          total=$((passed + failed))
+
+          echo ""
+          echo "=============================="
+          echo "  Test Summary"
+          echo "=============================="
+          echo "  Total:  $total"
+          echo "  Passed: $passed"
+          echo "  Failed: $failed"
+          echo "=============================="
+
+          if [ $exit_code -ne 0 ]; then
+            echo "  Result: FAILED"
+          else
+            echo "  Result: PASSED"
+          fi
+          echo "=============================="
+
+          exit $exit_code
+
+  docker:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build Docker image
+        run: docker build -t sfu-courses-api .
+
+      - name: Verify image exists
+        run: docker image inspect sfu-courses-api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, andy/parsed-prereqs]
   pull_request:
     branches: [main]
 
@@ -31,21 +31,19 @@ jobs:
           failed=$(echo "$output" | grep -c "^--- FAIL" || true)
           total=$((passed + failed))
 
-          echo ""
-          echo "=============================="
-          echo "  Test Summary"
-          echo "=============================="
-          echo "  Total:  $total"
-          echo "  Passed: $passed"
-          echo "  Failed: $failed"
-          echo "=============================="
-
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Test Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Total  | $total |" >> $GITHUB_STEP_SUMMARY
+          echo "| Passed | $passed |" >> $GITHUB_STEP_SUMMARY
+          echo "| Failed | $failed |" >> $GITHUB_STEP_SUMMARY
           if [ $exit_code -ne 0 ]; then
-            echo "  Result: FAILED"
+            echo "| Result | **FAILED** |" >> $GITHUB_STEP_SUMMARY
           else
-            echo "  Result: PASSED"
+            echo "| Result | **PASSED** |" >> $GITHUB_STEP_SUMMARY
           fi
-          echo "=============================="
 
           exit $exit_code
 
@@ -56,7 +54,19 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Build Docker image
-        run: docker build -t sfu-courses-api .
+        id: docker
+        run: |
+          docker build -t sfu-courses-api . 2>&1
+          image_size=$(docker image inspect sfu-courses-api --format '{{.Size}}' | awk '{printf "%.1f MB", $1/1024/1024}')
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Docker Build" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Image  | sfu-courses-api |" >> $GITHUB_STEP_SUMMARY
+          echo "| Size   | $image_size |" >> $GITHUB_STEP_SUMMARY
+          echo "| Result | **PASSED** |" >> $GITHUB_STEP_SUMMARY
 
       - name: Verify image exists
         run: docker image inspect sfu-courses-api

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -104,6 +104,7 @@ func (app *application) mount() http.Handler {
 	mux.HandleFunc("POST /update", app.manualUpdateHandler)
 
 	mux.HandleFunc("GET /v1/rest/outlines", app.getCourseOutlines)
+	mux.HandleFunc("GET /v1/rest/prerequisites", app.getPrerequisites)
 	mux.HandleFunc("GET /v1/rest/sections", app.getSections)
 	mux.HandleFunc("GET /v1/rest/instructors", app.getInstructors)
 	mux.HandleFunc("GET /v1/rest/reviews/instructors", app.getAllInstructorReviews)

--- a/cmd/api/outlines.go
+++ b/cmd/api/outlines.go
@@ -17,7 +17,6 @@ import (
 // @Param			dept	query		string				false	"Department code (e.g., cmpt, math)"
 // @Param			number	query		string				false	"Course number (e.g., 120, 225)"
 // @Param			short	query		bool				false	"Return short outline with only dept, number, title, and units"
-// @Param			SHORT	query		bool				false	"Return short outline with only dept, number, title, and units"
 // @Param			prereqs	query		bool				false	"Include parsed prerequisite expression trees"
 // @Success		200		{array}		model.CourseOutline	"List of course outlines"
 // @Failure		404		{object}	ErrorResponse		"No outlines found for the specified criteria"

--- a/cmd/api/outlines.go
+++ b/cmd/api/outlines.go
@@ -18,6 +18,7 @@ import (
 // @Param			number	query		string				false	"Course number (e.g., 120, 225)"
 // @Param			short	query		bool				false	"Return short outline with only dept, number, title, and units"
 // @Param			SHORT	query		bool				false	"Return short outline with only dept, number, title, and units"
+// @Param			prereqs	query		bool				false	"Include parsed prerequisite expression trees"
 // @Success		200		{array}		model.CourseOutline	"List of course outlines"
 // @Failure		404		{object}	ErrorResponse		"No outlines found for the specified criteria"
 // @Failure		500		{object}	ErrorResponse		"Internal server error"
@@ -28,6 +29,7 @@ func (app *application) getCourseOutlines(w http.ResponseWriter, r *http.Request
 	number := r.URL.Query().Get("number")
 	
 	isShort := strings.ToLower(r.URL.Query().Get("short")) == "true" || strings.ToLower(r.URL.Query().Get("SHORT")) == "true"
+	includePrereqs := strings.ToLower(r.URL.Query().Get("prereqs")) == "true"
 
 	outlines, err := app.store.Outlines.Get(ctx, dept, number)
 	if err != nil {
@@ -51,6 +53,21 @@ func (app *application) getCourseOutlines(w http.ResponseWriter, r *http.Request
 			})
 		}
 		writeJSON(w, http.StatusOK, shortOutlines)
+		return
+	}
+
+	if includePrereqs {
+		prereqMap := app.store.Outlines.GetPrereqMap()
+		result := make([]model.CourseOutlineWithPrereqs, 0, len(outlines))
+		for _, o := range outlines {
+			code := o.Dept + " " + o.Number
+			entry := model.CourseOutlineWithPrereqs{CourseOutline: o}
+			if node, ok := prereqMap[code]; ok {
+				entry.ParsedPrerequisites = &node
+			}
+			result = append(result, entry)
+		}
+		writeJSON(w, http.StatusOK, result)
 		return
 	}
 

--- a/cmd/api/prerequisites.go
+++ b/cmd/api/prerequisites.go
@@ -8,17 +8,17 @@ import (
 	"github.com/brianrahadi/sfucourses-api/internal/store"
 )
 
-// @Summary		Get parsed course prerequisites
-// @Description	Returns prerequisite expression trees for all courses, optionally filtered by department and/or course number
-// @Tags			Prerequisites
-// @Accept			json
-// @Produce		json
-// @Param			dept	query		string				false	"Department code (e.g., cmpt, math)"
-// @Param			number	query		string				false	"Course number (e.g., 120, 225)"
-// @Success		200		{object}	model.PrereqMap		"Map of course codes to prerequisite expression trees"
-// @Failure		404		{object}	ErrorResponse		"No prerequisites found for the specified criteria"
-// @Failure		500		{object}	ErrorResponse		"Internal server error"
-// @Router			/v1/rest/prerequisites [get]
+//	@Summary		Get parsed course prerequisites
+//	@Description	Returns prerequisite expression trees for all courses, optionally filtered by department and/or course number
+//	@Tags			Prerequisites
+//	@Accept			json
+//	@Produce		json
+//	@Param			dept	query		string			false	"Department code (e.g., cmpt, math)"
+//	@Param			number	query		string			false	"Course number (e.g., 120, 225)"
+//	@Success		200		{object}	model.PrereqMap	"Map of course codes to prerequisite expression trees"
+//	@Failure		404		{object}	ErrorResponse	"No prerequisites found for the specified criteria"
+//	@Failure		500		{object}	ErrorResponse	"Internal server error"
+//	@Router			/v1/rest/prerequisites [get]
 func (app *application) getPrerequisites(w http.ResponseWriter, r *http.Request) {
 	dept := r.URL.Query().Get("dept")
 	number := r.URL.Query().Get("number")

--- a/cmd/api/prerequisites.go
+++ b/cmd/api/prerequisites.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/brianrahadi/sfucourses-api/internal/model"
+	"github.com/brianrahadi/sfucourses-api/internal/store"
 )
 
 // @Summary		Get parsed course prerequisites
@@ -15,11 +16,17 @@ import (
 // @Param			dept	query		string				false	"Department code (e.g., cmpt, math)"
 // @Param			number	query		string				false	"Course number (e.g., 120, 225)"
 // @Success		200		{object}	model.PrereqMap		"Map of course codes to prerequisite expression trees"
+// @Failure		404		{object}	ErrorResponse		"No prerequisites found for the specified criteria"
 // @Failure		500		{object}	ErrorResponse		"Internal server error"
 // @Router			/v1/rest/prerequisites [get]
 func (app *application) getPrerequisites(w http.ResponseWriter, r *http.Request) {
 	dept := r.URL.Query().Get("dept")
 	number := r.URL.Query().Get("number")
+
+	if dept == "" && number != "" {
+		app.notFoundResponse(w, r, store.ErrNotFound)
+		return
+	}
 
 	prereqMap := app.store.Outlines.GetPrereqMap()
 
@@ -49,6 +56,11 @@ func (app *application) getPrerequisites(w http.ResponseWriter, r *http.Request)
 				filtered[code] = node
 			}
 		}
+	}
+
+	if dept != "" && number != "" && len(filtered) == 0 {
+		app.notFoundResponse(w, r, store.ErrNotFound)
+		return
 	}
 
 	writeJSON(w, http.StatusOK, filtered)

--- a/cmd/api/prerequisites.go
+++ b/cmd/api/prerequisites.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/brianrahadi/sfucourses-api/internal/model"
+)
+
+// @Summary		Get parsed course prerequisites
+// @Description	Returns prerequisite expression trees for all courses, optionally filtered by department and/or course number
+// @Tags			Prerequisites
+// @Accept			json
+// @Produce		json
+// @Param			dept	query		string				false	"Department code (e.g., cmpt, math)"
+// @Param			number	query		string				false	"Course number (e.g., 120, 225)"
+// @Success		200		{object}	model.PrereqMap		"Map of course codes to prerequisite expression trees"
+// @Failure		500		{object}	ErrorResponse		"Internal server error"
+// @Router			/v1/rest/prerequisites [get]
+func (app *application) getPrerequisites(w http.ResponseWriter, r *http.Request) {
+	dept := r.URL.Query().Get("dept")
+	number := r.URL.Query().Get("number")
+
+	prereqMap := app.store.Outlines.GetPrereqMap()
+
+	if dept == "" && number == "" {
+		writeJSON(w, http.StatusOK, prereqMap)
+		return
+	}
+
+	dept = strings.ToUpper(dept)
+	number = strings.ToUpper(number)
+
+	filtered := make(model.PrereqMap)
+	for code, node := range prereqMap {
+		parts := strings.SplitN(code, " ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		codeDept := parts[0]
+		codeNumber := parts[1]
+
+		if dept != "" && number != "" {
+			if codeDept == dept && codeNumber == number {
+				filtered[code] = node
+			}
+		} else if dept != "" {
+			if codeDept == dept {
+				filtered[code] = node
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, filtered)
+}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -124,6 +124,24 @@ const docTemplate = `{
                         "description": "Course number (e.g., 120, 225)",
                         "name": "number",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Return short outline with only dept, number, title, and units",
+                        "name": "short",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Return short outline with only dept, number, title, and units",
+                        "name": "SHORT",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Include parsed prerequisite expression trees",
+                        "name": "prereqs",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -151,9 +169,9 @@ const docTemplate = `{
                 }
             }
         },
-        "/v1/rest/reviews/instructors": {
+        "/v1/rest/prerequisites": {
             "get": {
-                "description": "Returns summary review data for all instructors from all_instructor_reviews.json",
+                "description": "Returns prerequisite expression trees for all courses, optionally filtered by department and/or course number",
                 "consumes": [
                     "application/json"
                 ],
@@ -161,17 +179,34 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Reviews"
+                    "Prerequisites"
                 ],
-                "summary": "Get all instructor reviews overview",
+                "summary": "Get parsed course prerequisites",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Department code (e.g., cmpt, math)",
+                        "name": "dept",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Course number (e.g., 120, 225)",
+                        "name": "number",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "List of instructor summaries",
+                        "description": "Map of course codes to prerequisite expression trees",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/model.ProfessorSummary"
-                            }
+                            "$ref": "#/definitions/model.PrereqMap"
+                        }
+                    },
+                    "404": {
+                        "description": "No prerequisites found for the specified criteria",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
                         }
                     },
                     "500": {
@@ -185,7 +220,7 @@ const docTemplate = `{
         },
         "/v1/rest/reviews/courses": {
             "get": {
-                "description": "Returns summary review data for all courses from all_course_reviews.json",
+                "description": "Returns summary review data for all courses",
                 "consumes": [
                     "application/json"
                 ],
@@ -247,6 +282,38 @@ const docTemplate = `{
                         "description": "Course not found",
                         "schema": {
                             "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/rest/reviews/instructors": {
+            "get": {
+                "description": "Returns summary review data for all instructors",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reviews"
+                ],
+                "summary": "Get all instructor reviews overview",
+                "responses": {
+                    "200": {
+                        "description": "List of instructor summaries",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.ProfessorSummary"
+                            }
                         }
                     },
                     "500": {
@@ -497,6 +564,28 @@ const docTemplate = `{
                 }
             }
         },
+        "model.CourseSummary": {
+            "description": "Summary review information for a course",
+            "type": "object",
+            "properties": {
+                "avg_difficulty": {
+                    "type": "number",
+                    "example": 2
+                },
+                "avg_rating": {
+                    "type": "number",
+                    "example": 4.5
+                },
+                "course_code": {
+                    "type": "string",
+                    "example": "SOC225"
+                },
+                "total_reviews": {
+                    "type": "integer",
+                    "example": 2
+                }
+            }
+        },
         "model.CourseWithSectionDetails": {
             "description": "Course with detailed section information",
             "type": "object",
@@ -661,8 +750,33 @@ const docTemplate = `{
                 }
             }
         },
+        "model.PrereqMap": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/model.PrereqNode"
+            }
+        },
+        "model.PrereqNode": {
+            "type": "object",
+            "properties": {
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.PrereqNode"
+                    }
+                },
+                "id": {
+                    "type": "string",
+                    "example": "CMPT 225"
+                },
+                "type": {
+                    "type": "string",
+                    "example": "and"
+                }
+            }
+        },
         "model.ProfessorSummary": {
-            "description": "Summary review information for a professor from reviews.json",
+            "description": "Summary review information for a professor",
             "type": "object",
             "properties": {
                 "Department": {
@@ -695,28 +809,6 @@ const docTemplate = `{
                 }
             }
         },
-        "model.CourseSummary": {
-            "description": "Summary review information for a course from all_course_reviews.json",
-            "type": "object",
-            "properties": {
-                "course_code": {
-                    "type": "string",
-                    "example": "SOC225"
-                },
-                "total_reviews": {
-                    "type": "integer",
-                    "example": 2
-                },
-                "avg_rating": {
-                    "type": "number",
-                    "example": 4.5
-                },
-                "avg_difficulty": {
-                    "type": "number",
-                    "example": 2.0
-                }
-            }
-        },
         "model.Review": {
             "description": "Detailed review information",
             "type": "object",
@@ -730,23 +822,23 @@ const docTemplate = `{
                     "example": "Sep 1st, 2020"
                 },
                 "difficulty": {
-                    "type": "number",
-                    "example": 3
+                    "type": "string",
+                    "example": "3.0"
                 },
                 "helpful": {
-                    "type": "integer",
-                    "example": 5
+                    "type": "string",
+                    "example": "5"
                 },
                 "metadata": {
                     "$ref": "#/definitions/model.ReviewMetadata"
                 },
                 "not_helpful": {
-                    "type": "integer",
-                    "example": 1
+                    "type": "string",
+                    "example": "1"
                 },
                 "rating": {
-                    "type": "number",
-                    "example": 4
+                    "type": "string",
+                    "example": "4.0"
                 },
                 "review_msg": {
                     "type": "string",
@@ -882,7 +974,7 @@ var SwaggerInfo = &swag.Spec{
 	BasePath:         "",
 	Schemes:          []string{"https"},
 	Title:            "sfucourses API",
-	Description:      "Unofficial API for accessing SFU course outlines, sections, and instructors robustly and used to power [sfucourses.com](https://sfucourses.com). Data is pulled from [SFU Course Outlines REST API](https://www.sfu.ca/outlines/help/api.html). This API is not affiliated with Simon Fraser University.",
+	Description:      "Unofficial API for accessing SFU course outlines, sections, instructors, and reviews robustly and used to power [sfucourses.com](https://sfucourses.com). Data is pulled from [SFU Course Outlines REST API](https://www.sfu.ca/outlines/help/api.html). This API is not affiliated with Simon Fraser University.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4,7 +4,7 @@
     ],
     "swagger": "2.0",
     "info": {
-        "description": "Unofficial API for accessing SFU course outlines, sections, and instructors robustly and used to power [sfucourses.com](https://sfucourses.com). Data is pulled from [SFU Course Outlines REST API](https://www.sfu.ca/outlines/help/api.html). This API is not affiliated with Simon Fraser University.",
+        "description": "Unofficial API for accessing SFU course outlines, sections, instructors, and reviews robustly and used to power [sfucourses.com](https://sfucourses.com). Data is pulled from [SFU Course Outlines REST API](https://www.sfu.ca/outlines/help/api.html). This API is not affiliated with Simon Fraser University.",
         "title": "sfucourses API",
         "contact": {}
     },
@@ -119,6 +119,24 @@
                         "description": "Course number (e.g., 120, 225)",
                         "name": "number",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Return short outline with only dept, number, title, and units",
+                        "name": "short",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Return short outline with only dept, number, title, and units",
+                        "name": "SHORT",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Include parsed prerequisite expression trees",
+                        "name": "prereqs",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -146,9 +164,9 @@
                 }
             }
         },
-        "/v1/rest/reviews/instructors": {
+        "/v1/rest/prerequisites": {
             "get": {
-                "description": "Returns summary review data for all instructors from all_instructor_reviews.json",
+                "description": "Returns prerequisite expression trees for all courses, optionally filtered by department and/or course number",
                 "consumes": [
                     "application/json"
                 ],
@@ -156,17 +174,34 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Reviews"
+                    "Prerequisites"
                 ],
-                "summary": "Get all instructor reviews overview",
+                "summary": "Get parsed course prerequisites",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Department code (e.g., cmpt, math)",
+                        "name": "dept",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Course number (e.g., 120, 225)",
+                        "name": "number",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "List of instructor summaries",
+                        "description": "Map of course codes to prerequisite expression trees",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/model.ProfessorSummary"
-                            }
+                            "$ref": "#/definitions/model.PrereqMap"
+                        }
+                    },
+                    "404": {
+                        "description": "No prerequisites found for the specified criteria",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
                         }
                     },
                     "500": {
@@ -180,7 +215,7 @@
         },
         "/v1/rest/reviews/courses": {
             "get": {
-                "description": "Returns summary review data for all courses from all_course_reviews.json",
+                "description": "Returns summary review data for all courses",
                 "consumes": [
                     "application/json"
                 ],
@@ -242,6 +277,38 @@
                         "description": "Course not found",
                         "schema": {
                             "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/rest/reviews/instructors": {
+            "get": {
+                "description": "Returns summary review data for all instructors",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reviews"
+                ],
+                "summary": "Get all instructor reviews overview",
+                "responses": {
+                    "200": {
+                        "description": "List of instructor summaries",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.ProfessorSummary"
+                            }
                         }
                     },
                     "500": {
@@ -492,6 +559,28 @@
                 }
             }
         },
+        "model.CourseSummary": {
+            "description": "Summary review information for a course",
+            "type": "object",
+            "properties": {
+                "avg_difficulty": {
+                    "type": "number",
+                    "example": 2
+                },
+                "avg_rating": {
+                    "type": "number",
+                    "example": 4.5
+                },
+                "course_code": {
+                    "type": "string",
+                    "example": "SOC225"
+                },
+                "total_reviews": {
+                    "type": "integer",
+                    "example": 2
+                }
+            }
+        },
         "model.CourseWithSectionDetails": {
             "description": "Course with detailed section information",
             "type": "object",
@@ -656,8 +745,33 @@
                 }
             }
         },
+        "model.PrereqMap": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/model.PrereqNode"
+            }
+        },
+        "model.PrereqNode": {
+            "type": "object",
+            "properties": {
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.PrereqNode"
+                    }
+                },
+                "id": {
+                    "type": "string",
+                    "example": "CMPT 225"
+                },
+                "type": {
+                    "type": "string",
+                    "example": "and"
+                }
+            }
+        },
         "model.ProfessorSummary": {
-            "description": "Summary review information for a professor from reviews.json",
+            "description": "Summary review information for a professor",
             "type": "object",
             "properties": {
                 "Department": {
@@ -690,28 +804,6 @@
                 }
             }
         },
-        "model.CourseSummary": {
-            "description": "Summary review information for a course from all_course_reviews.json",
-            "type": "object",
-            "properties": {
-                "course_code": {
-                    "type": "string",
-                    "example": "SOC225"
-                },
-                "total_reviews": {
-                    "type": "integer",
-                    "example": 2
-                },
-                "avg_rating": {
-                    "type": "number",
-                    "example": 4.5
-                },
-                "avg_difficulty": {
-                    "type": "number",
-                    "example": 2.0
-                }
-            }
-        },
         "model.Review": {
             "description": "Detailed review information",
             "type": "object",
@@ -725,23 +817,23 @@
                     "example": "Sep 1st, 2020"
                 },
                 "difficulty": {
-                    "type": "number",
-                    "example": 3
+                    "type": "string",
+                    "example": "3.0"
                 },
                 "helpful": {
-                    "type": "integer",
-                    "example": 5
+                    "type": "string",
+                    "example": "5"
                 },
                 "metadata": {
                     "$ref": "#/definitions/model.ReviewMetadata"
                 },
                 "not_helpful": {
-                    "type": "integer",
-                    "example": 1
+                    "type": "string",
+                    "example": "1"
                 },
                 "rating": {
-                    "type": "number",
-                    "example": 4
+                    "type": "string",
+                    "example": "4.0"
                 },
                 "review_msg": {
                     "type": "string",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -91,6 +91,22 @@ definitions:
         example: 25
         type: integer
     type: object
+  model.CourseSummary:
+    description: Summary review information for a course
+    properties:
+      avg_difficulty:
+        example: 2
+        type: number
+      avg_rating:
+        example: 4.5
+        type: number
+      course_code:
+        example: SOC225
+        type: string
+      total_reviews:
+        example: 2
+        type: integer
+    type: object
   model.CourseWithSectionDetails:
     description: Course with detailed section information
     properties:
@@ -209,8 +225,25 @@ definitions:
         example: 85%
         type: string
     type: object
+  model.PrereqMap:
+    additionalProperties:
+      $ref: '#/definitions/model.PrereqNode'
+    type: object
+  model.PrereqNode:
+    properties:
+      children:
+        items:
+          $ref: '#/definitions/model.PrereqNode'
+        type: array
+      id:
+        example: CMPT 225
+        type: string
+      type:
+        example: and
+        type: string
+    type: object
   model.ProfessorSummary:
-    description: Summary review information for a professor from reviews.json
+    description: Summary review information for a professor
     properties:
       Department:
         example: Gender Studies
@@ -234,22 +267,6 @@ definitions:
         example: 50%
         type: string
     type: object
-  model.CourseSummary:
-    description: Summary review information for a course from all_course_reviews.json
-    properties:
-      course_code:
-        example: SOC225
-        type: string
-      total_reviews:
-        example: 2
-        type: integer
-      avg_rating:
-        example: 4.5
-        type: number
-      avg_difficulty:
-        example: 2.0
-        type: number
-    type: object
   model.Review:
     description: Detailed review information
     properties:
@@ -260,19 +277,19 @@ definitions:
         example: Sep 1st, 2020
         type: string
       difficulty:
-        example: 3
-        type: number
+        example: "3.0"
+        type: string
       helpful:
-        example: 5
-        type: integer
+        example: "5"
+        type: string
       metadata:
         $ref: '#/definitions/model.ReviewMetadata'
       not_helpful:
-        example: 1
-        type: integer
+        example: "1"
+        type: string
       rating:
-        example: 4
-        type: number
+        example: "4.0"
+        type: string
       review_msg:
         example: Great professor!
         type: string
@@ -355,9 +372,9 @@ definitions:
 host: api.sfucourses.com
 info:
   contact: {}
-  description: Unofficial API for accessing SFU course outlines, sections, and instructors
-    robustly and used to power [sfucourses.com](https://sfucourses.com). Data is pulled
-    from [SFU Course Outlines REST API](https://www.sfu.ca/outlines/help/api.html).
+  description: Unofficial API for accessing SFU course outlines, sections, instructors,
+    and reviews robustly and used to power [sfucourses.com](https://sfucourses.com).
+    Data is pulled from [SFU Course Outlines REST API](https://www.sfu.ca/outlines/help/api.html).
     This API is not affiliated with Simon Fraser University.
   title: sfucourses API
 paths:
@@ -432,6 +449,18 @@ paths:
         in: query
         name: number
         type: string
+      - description: Return short outline with only dept, number, title, and units
+        in: query
+        name: short
+        type: boolean
+      - description: Return short outline with only dept, number, title, and units
+        in: query
+        name: SHORT
+        type: boolean
+      - description: Include parsed prerequisite expression trees
+        in: query
+        name: prereqs
+        type: boolean
       produces:
       - application/json
       responses:
@@ -452,32 +481,44 @@ paths:
       summary: Get course outlines
       tags:
       - Outlines
-  /v1/rest/reviews/instructors:
+  /v1/rest/prerequisites:
     get:
       consumes:
       - application/json
-      description: Returns summary review data for all instructors from all_instructor_reviews.json
+      description: Returns prerequisite expression trees for all courses, optionally
+        filtered by department and/or course number
+      parameters:
+      - description: Department code (e.g., cmpt, math)
+        in: query
+        name: dept
+        type: string
+      - description: Course number (e.g., 120, 225)
+        in: query
+        name: number
+        type: string
       produces:
       - application/json
       responses:
         "200":
-          description: List of instructor summaries
+          description: Map of course codes to prerequisite expression trees
           schema:
-            items:
-              $ref: '#/definitions/model.ProfessorSummary'
-            type: array
+            $ref: '#/definitions/model.PrereqMap'
+        "404":
+          description: No prerequisites found for the specified criteria
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
         "500":
           description: Internal server error
           schema:
             $ref: '#/definitions/main.ErrorResponse'
-      summary: Get all instructor reviews overview
+      summary: Get parsed course prerequisites
       tags:
-      - Reviews
+      - Prerequisites
   /v1/rest/reviews/courses:
     get:
       consumes:
       - application/json
-      description: Returns summary review data for all courses from all_course_reviews.json
+      description: Returns summary review data for all courses
       produces:
       - application/json
       responses:
@@ -520,6 +561,27 @@ paths:
           schema:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Get course reviews
+      tags:
+      - Reviews
+  /v1/rest/reviews/instructors:
+    get:
+      consumes:
+      - application/json
+      description: Returns summary review data for all instructors
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of instructor summaries
+          schema:
+            items:
+              $ref: '#/definitions/model.ProfessorSummary'
+            type: array
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+      summary: Get all instructor reviews overview
       tags:
       - Reviews
   /v1/rest/reviews/instructors/{instructor_name}:

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -29,7 +29,7 @@ func GetInt(key string, fallback int) int {
 		val := os.Getenv(key)
 		valAsInt, err := strconv.Atoi(val)
 		if err != nil {
-			log.Fatal("Trouble loading int production environment - %v", key)
+			log.Fatalf("Trouble loading int production environment - %v", key)
 			return fallback
 		}
 		return valAsInt

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -213,5 +213,23 @@ type CourseSummary struct {
 	CourseCode    string  `json:"course_code" example:"SOC225" description:"Course code"`
 	TotalReviews  int     `json:"total_reviews" example:"2" description:"Total number of reviews"`
 	AvgRating     float64 `json:"avg_rating" example:"4.5" description:"Average rating"`
-	AvgDifficulty float64 `json:"avg_difficulty" example:"2.0" description:"Average difficulty"`
+	AvgDifficulty float64 `json:"avg_difficulty" example:"2.0" description:"Average difficulty rating"`
+}
+
+// PrereqNode represents a node in a prerequisite expression tree.
+// Type "course": a single course or special token (ID field populated).
+// Type "and"/"or": logical operator node (Children field populated).
+type PrereqNode struct {
+	Type     string       `json:"type" example:"and" description:"Node type: course, and, or"`
+	ID       string       `json:"id,omitempty" example:"CMPT 225" description:"Course code or special token (for type=course)"`
+	Children []PrereqNode `json:"children,omitempty" description:"Child nodes (for type=and/or)"`
+}
+
+// PrereqMap maps course codes to their parsed prerequisite trees.
+type PrereqMap map[string]PrereqNode
+
+// CourseOutlineWithPrereqs is a CourseOutline with parsed prerequisite data.
+type CourseOutlineWithPrereqs struct {
+	CourseOutline
+	ParsedPrerequisites *PrereqNode `json:"parsedPrerequisites,omitempty"`
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -1,7 +1,5 @@
 package model
 
-import "encoding/json"
-
 // CourseOutline represents the general information about a course
 // @Description Course outline information including general details and offerings
 type CourseOutline struct {
@@ -150,14 +148,14 @@ type ReviewMetadata struct {
 // Review represents a detailed review
 // @Description Detailed review information
 type Review struct {
-	Rating     json.Number    `json:"rating" example:"4.0" description:"Review rating"`
-	Difficulty json.Number    `json:"difficulty" example:"3.0" description:"Difficulty rating"`
+	Rating     string         `json:"rating" example:"4.0" description:"Review rating"`
+	Difficulty string         `json:"difficulty" example:"3.0" description:"Difficulty rating"`
 	CourseCode string         `json:"course_code" example:"BUS251" description:"Course code"`
 	Date       string         `json:"date" example:"Sep 1st, 2020" description:"Review date"`
 	Metadata   ReviewMetadata `json:"metadata" description:"Review metadata"`
 	ReviewMsg  string         `json:"review_msg" example:"Great professor!" description:"Review message"`
-	Helpful    json.Number    `json:"helpful" example:"5" description:"Number of helpful votes"`
-	NotHelpful json.Number    `json:"not_helpful" example:"1" description:"Number of not helpful votes"`
+	Helpful    string         `json:"helpful" example:"5" description:"Number of helpful votes"`
+	NotHelpful string         `json:"not_helpful" example:"1" description:"Number of not helpful votes"`
 	Tags       []string       `json:"tags" example:"clear grading criteria,participation matters" description:"Review tags"`
 }
 

--- a/internal/prereq/parser.go
+++ b/internal/prereq/parser.go
@@ -197,14 +197,12 @@ func (p *parser) peek() *token {
 	return &p.tokens[p.pos]
 }
 
-func (p *parser) advance() token {
-	t := p.tokens[p.pos]
+func (p *parser) advance() *token {
+	if p.pos >= len(p.tokens) {
+		return nil
+	}
+	t := &p.tokens[p.pos]
 	p.pos++
-	return t
-}
-
-func (p *parser) expect(typ tokenType) token {
-	t := p.advance()
 	return t
 }
 
@@ -289,11 +287,16 @@ func (p *parser) factor() *model.PrereqNode {
 	if t.typ == tokLParen {
 		p.advance()
 		node := p.expression()
-		p.expect(tokRParen)
+		if rt := p.peek(); rt != nil && rt.typ == tokRParen {
+			p.advance()
+		}
 		return node
 	}
 
 	tok := p.advance()
+	if tok == nil {
+		return nil
+	}
 
 	switch tok.typ {
 	case tokCourse:

--- a/internal/prereq/parser.go
+++ b/internal/prereq/parser.go
@@ -1,0 +1,397 @@
+package prereq
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/brianrahadi/sfucourses-api/internal/model"
+)
+
+type tokenType int
+
+const (
+	tokCourse tokenType = iota
+	tokLParen
+	tokRParen
+	tokAnd
+	tokOr
+	tokComma
+	tokSemicolon
+	tokSpecial
+	tokProse
+)
+
+type token struct {
+	typ tokenType
+	val string
+}
+
+var (
+	coursePattern = regexp.MustCompile(`^([A-Z]{2,4})\s+(\d{3}[A-Z]?)`)
+	numberPattern = regexp.MustCompile(`^(\d{2,3}[A-Z]?)`)
+	unitsPattern  = regexp.MustCompile(`(?i)^(\d+)\s+units?\b`)
+	validIDPattern = regexp.MustCompile(`^[A-Z]{2,4}\s+\d{3}[A-Z]?$|^(UNITS|PERMISSION|COREQUISITE):`)
+)
+
+func stripGradeText(s string) string {
+	s = regexp.MustCompile(`(?i),?\s*all\s+with\s+a?\s*minimum\s+grade\s+of\s+[A-Z][+-]?`).ReplaceAllString(s, "")
+	s = regexp.MustCompile(`(?i),?\s*both\s+with\s+a?\s*(?:minimum\s+)?grade\s+(?:of\s+)?(?:at\s+least|of)\s+[A-Z][+-]?`).ReplaceAllString(s, "")
+	s = regexp.MustCompile(`(?i),?\s*with\s+a?\s*(?:minimum\s+)?grade\s+(?:of\s+)?(?:at\s+least|of)\s+[A-Z][+-]?`).ReplaceAllString(s, "")
+	s = regexp.MustCompile(`(?i),?\s*with\s+grades?\s+(?:of\s+)?(?:at\s+least|of)\s+[A-Z][+-]?`).ReplaceAllString(s, "")
+	s = regexp.MustCompile(`(?i)\s*;+\s*or\b`).ReplaceAllString(s, " or ")
+	s = regexp.MustCompile(`(?i)\s*;+\s*`).ReplaceAllString(s, " or ")
+	s = regexp.MustCompile(`,\s*\.`).ReplaceAllString(s, ".")
+	s = regexp.MustCompile(`\s+`).ReplaceAllString(s, " ")
+	return strings.TrimSpace(s)
+}
+
+func stripFillerPhrases(s string) string {
+_phrases := []string{
+	`(?i)\bincluding\s+one\s+of\b`,
+	`(?i)\bany\s+one\s+of\s+the\s+following\s*:?\s*`,
+	`(?i)\bany\s+of\s+the\s+following\s*:?\s*`,
+	`(?i)\bone\s+of\s+the\s+following\s*:?\s*`,
+	`(?i)\bboth\s+with\b`,
+	`(?i)\ball\s+with\b`,
+}
+	for _, p := range _phrases {
+		s = regexp.MustCompile(p).ReplaceAllString(s, "")
+	}
+	return s
+}
+
+func tokenize(input string) []token {
+	input = stripGradeText(input)
+	input = stripFillerPhrases(input)
+
+	var tokens []token
+	i := 0
+	n := len(input)
+	lastDept := ""
+
+	for i < n {
+		ch := input[i]
+
+		if ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' {
+			i++
+			continue
+		}
+
+		if ch == '(' {
+			tokens = append(tokens, token{tokLParen, "("})
+			i++
+			continue
+		}
+
+		if ch == ')' {
+			tokens = append(tokens, token{tokRParen, ")"})
+			i++
+			continue
+		}
+
+		if ch == ',' {
+			tokens = append(tokens, token{tokComma, ","})
+			i++
+			continue
+		}
+
+		remaining := input[i:]
+
+		if strings.HasPrefix(strings.ToLower(remaining), "corequisite") {
+			idx := strings.Index(strings.ToLower(remaining), ":")
+			if idx > 0 {
+				rest := strings.TrimSpace(remaining[idx+1:])
+				endIdx := strings.IndexAny(rest, ",;(()")
+				if endIdx < 0 {
+					endIdx = len(rest)
+				}
+				val := strings.TrimSpace(rest[:endIdx])
+				tokens = append(tokens, token{tokSpecial, "COREQUISITE:" + strings.ToUpper(val)})
+				i += idx + 1 + endIdx
+				continue
+			}
+		}
+
+		if strings.HasPrefix(strings.ToLower(remaining), "permission") {
+			endIdx := strings.IndexAny(remaining, ",;()")
+			if endIdx < 0 {
+				endIdx = len(remaining)
+			}
+			val := strings.TrimSpace(remaining[:endIdx])
+			tokens = append(tokens, token{tokSpecial, "PERMISSION:" + strings.ToLower(val)})
+			i += endIdx
+			continue
+		}
+
+		if m := unitsPattern.FindStringSubmatch(remaining); m != nil {
+			tokens = append(tokens, token{tokSpecial, "UNITS:" + m[1]})
+			i += len(m[0])
+			continue
+		}
+
+		if len(remaining) >= 3 && strings.EqualFold(remaining[:3], "and") {
+			if len(remaining) == 3 || remaining[3] == ' ' || remaining[3] == '(' || remaining[3] == ')' {
+				tokens = append(tokens, token{tokAnd, "and"})
+				i += 3
+				continue
+			}
+		}
+
+		if len(remaining) >= 2 && strings.EqualFold(remaining[:2], "or") {
+			if len(remaining) == 2 || remaining[2] == ' ' || remaining[2] == '(' || remaining[2] == ')' {
+				tokens = append(tokens, token{tokOr, "or"})
+				i += 2
+				continue
+			}
+		}
+
+		if m := coursePattern.FindStringSubmatch(strings.ToUpper(remaining)); m != nil {
+			code := m[1] + " " + m[2]
+			lastDept = m[1]
+			tokens = append(tokens, token{tokCourse, code})
+			i += len(m[0])
+			continue
+		}
+
+		if m := numberPattern.FindStringSubmatch(strings.ToUpper(remaining)); m != nil && lastDept != "" {
+			code := lastDept + " " + m[1]
+			tokens = append(tokens, token{tokCourse, code})
+			i += len(m[0])
+			continue
+		}
+
+		if ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z' {
+			endIdx := i + 1
+			for endIdx < n && input[endIdx] != ' ' && input[endIdx] != '(' && input[endIdx] != ')' && input[endIdx] != ',' && input[endIdx] != ';' {
+				endIdx++
+			}
+			word := remaining[:endIdx-i]
+			lower := strings.ToLower(word)
+			if lower == "and" {
+				tokens = append(tokens, token{tokAnd, "and"})
+			} else if lower == "or" {
+				tokens = append(tokens, token{tokOr, "or"})
+			} else {
+				tokens = append(tokens, token{tokProse, word})
+			}
+			i = endIdx
+			continue
+		}
+
+		i++
+	}
+
+	return tokens
+}
+
+type parser struct {
+	tokens   []token
+	pos      int
+	lastDept string
+}
+
+func (p *parser) peek() *token {
+	if p.pos >= len(p.tokens) {
+		return nil
+	}
+	return &p.tokens[p.pos]
+}
+
+func (p *parser) advance() token {
+	t := p.tokens[p.pos]
+	p.pos++
+	return t
+}
+
+func (p *parser) expect(typ tokenType) token {
+	t := p.advance()
+	return t
+}
+
+// expression = term (and_op term)*
+// and_op = 'and' | ','
+// Adjacent and_ops (e.g. ", and") are collapsed.
+func (p *parser) expression() *model.PrereqNode {
+	left := p.term()
+	if left == nil {
+		return nil
+	}
+
+	for {
+		t := p.peek()
+		if t == nil {
+			break
+		}
+		if t.typ == tokAnd || t.typ == tokComma {
+			p.advance()
+			// Skip adjacent AND operators (e.g. ", and" -> just one AND)
+			for {
+				next := p.peek()
+				if next != nil && (next.typ == tokAnd || next.typ == tokComma) {
+					p.advance()
+					continue
+				}
+				break
+			}
+			right := p.term()
+			if right == nil {
+				break
+			}
+			left = &model.PrereqNode{
+				Type:     "and",
+				Children: []model.PrereqNode{*left, *right},
+			}
+			continue
+		}
+		break
+	}
+
+	return left
+}
+
+// term = factor (('or' | ';') factor)*
+func (p *parser) term() *model.PrereqNode {
+	left := p.factor()
+	if left == nil {
+		return nil
+	}
+
+	for {
+		t := p.peek()
+		if t == nil {
+			break
+		}
+		if t.typ == tokOr || t.typ == tokSemicolon {
+			p.advance()
+			right := p.factor()
+			if right == nil {
+				break
+			}
+			left = &model.PrereqNode{
+				Type:     "or",
+				Children: []model.PrereqNode{*left, *right},
+			}
+			continue
+		}
+		break
+	}
+
+	return left
+}
+
+// factor = '(' expression ')' | course | special | prose
+func (p *parser) factor() *model.PrereqNode {
+	t := p.peek()
+	if t == nil {
+		return nil
+	}
+
+	if t.typ == tokLParen {
+		p.advance()
+		node := p.expression()
+		p.expect(tokRParen)
+		return node
+	}
+
+	tok := p.advance()
+
+	switch tok.typ {
+	case tokCourse:
+		p.lastDept = tok.val[:strings.Index(tok.val, " ")]
+		return &model.PrereqNode{Type: "course", ID: tok.val}
+	case tokSpecial:
+		return &model.PrereqNode{Type: "course", ID: tok.val}
+	default:
+		return nil
+	}
+}
+
+// Parse converts a raw prerequisite string into a PrereqNode AST.
+// Returns nil if the input is empty or unparseable.
+func Parse(raw string) *model.PrereqNode {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	tokens := tokenize(raw)
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	p := &parser{tokens: tokens}
+	node := p.expression()
+
+	if node == nil {
+		return nil
+	}
+
+	return prune(flatten(node))
+}
+
+// prune removes invalid course nodes (IDs that aren't valid course codes or
+// special tokens) and collapses meaningless parent nodes.
+func prune(n *model.PrereqNode) *model.PrereqNode {
+	if n == nil {
+		return nil
+	}
+
+	if n.Type == "course" {
+		if validIDPattern.MatchString(n.ID) {
+			return n
+		}
+		return nil
+	}
+
+	var kept []model.PrereqNode
+	for _, child := range n.Children {
+		if pruned := prune(&child); pruned != nil {
+			kept = append(kept, *pruned)
+		}
+	}
+
+	if len(kept) == 0 {
+		return nil
+	}
+	if len(kept) == 1 {
+		return &kept[0]
+	}
+
+	n.Children = kept
+	return n
+}
+
+// flatten collapses nested same-type nodes into a single level.
+// e.g. AND(AND(A, B), C) -> AND(A, B, C)
+func flatten(n *model.PrereqNode) *model.PrereqNode {
+	if n == nil || n.Type == "course" {
+		return n
+	}
+	for i := range n.Children {
+		flattened := flatten(&n.Children[i])
+		n.Children[i] = *flattened
+	}
+	var flat []model.PrereqNode
+	for _, child := range n.Children {
+		if child.Type == n.Type {
+			flat = append(flat, child.Children...)
+		} else {
+			flat = append(flat, child)
+		}
+	}
+	n.Children = flat
+	return n
+}
+
+// ParseAll parses prerequisites for all outlines and returns a PrereqMap.
+func ParseAll(outlines []model.CourseOutline) model.PrereqMap {
+	m := make(model.PrereqMap, len(outlines))
+	for _, o := range outlines {
+		code := o.Dept + " " + o.Number
+		node := Parse(o.Prerequisites)
+		if node != nil {
+			m[code] = *node
+		}
+	}
+	return m
+}

--- a/internal/prereq/parser_test.go
+++ b/internal/prereq/parser_test.go
@@ -194,6 +194,28 @@ func TestParsePrunesProse(t *testing.T) {
 	}
 }
 
+func TestParseUnbalancedParens(t *testing.T) {
+	cases := []struct {
+		input      string
+		expectNil  bool
+	}{
+		{"(CMPT 225", false},
+		{"CMPT 225)", false},
+		{"((CMPT 225)", false},
+		{"(", true},
+		{")", true},
+	}
+	for _, c := range cases {
+		got := Parse(c.input)
+		if c.expectNil && got != nil {
+			t.Errorf("Parse(%q) = %v, want nil", c.input, got)
+		}
+		if !c.expectNil && got == nil {
+			t.Errorf("Parse(%q) returned nil, expected a node", c.input)
+		}
+	}
+}
+
 func TestParseAll(t *testing.T) {
 	outlines := []model.CourseOutline{
 		{Dept: "CMPT", Number: "300", Prerequisites: "CMPT 225"},

--- a/internal/prereq/parser_test.go
+++ b/internal/prereq/parser_test.go
@@ -1,0 +1,270 @@
+package prereq
+
+import (
+	"testing"
+
+	"github.com/brianrahadi/sfucourses-api/internal/model"
+)
+
+func node(typ string, children ...model.PrereqNode) model.PrereqNode {
+	return model.PrereqNode{Type: typ, Children: children}
+}
+
+func course(id string) model.PrereqNode {
+	return model.PrereqNode{Type: "course", ID: id}
+}
+
+func TestParseEmpty(t *testing.T) {
+	if got := Parse(""); got != nil {
+		t.Errorf("Parse(\"\") = %v, want nil", got)
+	}
+	if got := Parse("  "); got != nil {
+		t.Errorf("Parse(\"  \") = %v, want nil", got)
+	}
+}
+
+func TestParseSingleCourse(t *testing.T) {
+	got := Parse("CMPT 225")
+	want := course("CMPT 225")
+	if got.ID != want.ID || got.Type != want.Type {
+		t.Errorf("Parse(\"CMPT 225\") = %v, want %v", got, want)
+	}
+}
+
+func TestParseSimpleAnd(t *testing.T) {
+	got := Parse("CMPT 225 and MACM 101")
+	if got.Type != "and" {
+		t.Fatalf("expected type 'and', got %q", got.Type)
+	}
+	if len(got.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(got.Children))
+	}
+	if got.Children[0].ID != "CMPT 225" {
+		t.Errorf("child[0].ID = %q, want \"CMPT 225\"", got.Children[0].ID)
+	}
+	if got.Children[1].ID != "MACM 101" {
+		t.Errorf("child[1].ID = %q, want \"MACM 101\"", got.Children[1].ID)
+	}
+}
+
+func TestParseSimpleOr(t *testing.T) {
+	got := Parse("CMPT 125 or CMPT 135")
+	if got.Type != "or" {
+		t.Fatalf("expected type 'or', got %q", got.Type)
+	}
+	if len(got.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(got.Children))
+	}
+	if got.Children[0].ID != "CMPT 125" || got.Children[1].ID != "CMPT 135" {
+		t.Errorf("unexpected children: %v", got.Children)
+	}
+}
+
+func TestParseCMPT300(t *testing.T) {
+	got := Parse("CMPT 225 and (CMPT 295 or ENSC 254), all with a minimum grade of C-.")
+	if got.Type != "and" {
+		t.Fatalf("expected root type 'and', got %q", got.Type)
+	}
+	if len(got.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(got.Children))
+	}
+	if got.Children[0].ID != "CMPT 225" {
+		t.Errorf("child[0] = %v, want course CMPT 225", got.Children[0])
+	}
+	orNode := got.Children[1]
+	if orNode.Type != "or" || len(orNode.Children) != 2 {
+		t.Errorf("child[1] = %v, want or(CMPT 295, ENSC 254)", orNode)
+	}
+}
+
+func TestParseCMPT307(t *testing.T) {
+	raw := "CMPT 225, (MACM 201 or CMPT 210), (MATH 150 or MATH 151), and (MATH 232 or MATH 240), all with a minimum grade of C-."
+	got := Parse(raw)
+	if got.Type != "and" {
+		t.Fatalf("expected root type 'and', got %q", got.Type)
+	}
+	if len(got.Children) != 4 {
+		t.Fatalf("expected 4 children, got %d: %v", len(got.Children), got)
+	}
+}
+
+func TestParseCMPT383(t *testing.T) {
+	raw := "CMPT 225 and (MACM 101 or (ENSC 251 and ENSC 252)), all with a minimum grade of C-."
+	got := Parse(raw)
+	if got.Type != "and" {
+		t.Fatalf("expected root type 'and', got %q", got.Type)
+	}
+	if len(got.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(got.Children))
+	}
+	orChild := got.Children[1]
+	if orChild.Type != "or" {
+		t.Fatalf("expected child[1] type 'or', got %q", orChild.Type)
+	}
+	inner := orChild.Children[1]
+	if inner.Type != "and" {
+		t.Fatalf("expected nested 'and', got %q", inner.Type)
+	}
+}
+
+func TestParseMATH232(t *testing.T) {
+	raw := "MATH 150 or 151 or MACM 101, with a minimum grade of C-; or MATH 154 or 157, both with a grade of at least B."
+	got := Parse(raw)
+	if got.Type != "or" {
+		t.Fatalf("expected root type 'or', got %q", got.Type)
+	}
+}
+
+func TestParseShorthandDept(t *testing.T) {
+	got := Parse("BISC 101, BISC 102, both with a minimum grade of C-.")
+	if got.Type != "and" {
+		t.Fatalf("expected type 'and', got %q", got.Type)
+	}
+	if len(got.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(got.Children))
+	}
+	if got.Children[0].ID != "BISC 101" || got.Children[1].ID != "BISC 102" {
+		t.Errorf("unexpected children: %v", got.Children)
+	}
+}
+
+func TestParseUnits(t *testing.T) {
+	got := Parse("45 units")
+	if got == nil {
+		t.Fatal("expected non-nil node")
+	}
+	if got.Type != "course" || got.ID != "UNITS:45" {
+		t.Errorf("got %v, want course(UNITS:45)", got)
+	}
+}
+
+func TestParsePermission(t *testing.T) {
+	got := Parse("Permission of the instructor")
+	if got == nil {
+		t.Fatal("expected non-nil node")
+	}
+	if got.Type != "course" || got.ID != "PERMISSION:permission of the instructor" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseCorequisite(t *testing.T) {
+	got := Parse("ACMA 201, Corequisite: STAT 285")
+	if got == nil {
+		t.Fatal("expected non-nil node")
+	}
+	if got.Type != "and" {
+		t.Fatalf("expected type 'and', got %q", got.Type)
+	}
+	if len(got.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(got.Children))
+	}
+	if got.Children[1].ID != "COREQUISITE:STAT 285" {
+		t.Errorf("child[1] = %v, want COREQUISITE:STAT 285", got.Children[1])
+	}
+}
+
+func TestParseComplexOrOfAnds(t *testing.T) {
+	raw := "(CMPT 125 and MACM 101) or (CMPT 225 and CMPT 295)"
+	got := Parse(raw)
+	if got.Type != "or" {
+		t.Fatalf("expected root type 'or', got %q: %v", got.Type, got)
+	}
+	if len(got.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d: %v", len(got.Children), got)
+	}
+	for i, child := range got.Children {
+		if child.Type != "and" {
+			t.Errorf("child[%d].Type = %q, want 'and'", i, child.Type)
+		}
+	}
+}
+
+func TestParsePrunesInvalidCourseCodes(t *testing.T) {
+	got := Parse("BC Math 12 or equivalent is recommended")
+	if got != nil {
+		t.Errorf("expected nil for unparseable prereq, got %v", got)
+	}
+}
+
+func TestParsePrunesProse(t *testing.T) {
+	got := Parse("Students must apply and receive permission from the co-op coordinator")
+	if got != nil {
+		t.Errorf("expected nil for prose-only prereq, got %v", got)
+	}
+}
+
+func TestParseAll(t *testing.T) {
+	outlines := []model.CourseOutline{
+		{Dept: "CMPT", Number: "300", Prerequisites: "CMPT 225"},
+		{Dept: "CMPT", Number: "100", Prerequisites: ""},
+	}
+	m := ParseAll(outlines)
+	if _, ok := m["CMPT 300"]; !ok {
+		t.Error("expected CMPT 300 in map")
+	}
+	if _, ok := m["CMPT 100"]; ok {
+		t.Error("did not expect CMPT 100 in map (empty prereqs)")
+	}
+}
+
+func TestParseCMPT225(t *testing.T) {
+	raw := "(MACM 101 and (CMPT 125, CMPT 129 or CMPT 135)) or (ENSC 251 and ENSC 252), all with a minimum grade of C-."
+	got := Parse(raw)
+	if got.Type != "or" {
+		t.Fatalf("expected root type 'or', got %q: %v", got.Type, got)
+	}
+	if len(got.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d: %v", len(got.Children), got)
+	}
+	left := got.Children[0]
+	if left.Type != "and" {
+		t.Errorf("left child type = %q, want 'and': %v", left.Type, left)
+	}
+	right := got.Children[1]
+	if right.Type != "and" {
+		t.Errorf("right child type = %q, want 'and': %v", right.Type, right)
+	}
+}
+
+func TestParseSimpleCourseWithGrade(t *testing.T) {
+	got := Parse("CMPT 135 with a minimum grade of C-.")
+	if got.Type != "course" || got.ID != "CMPT 135" {
+		t.Errorf("got %v, want course(CMPT 135)", got)
+	}
+}
+
+func TestParseOrWithSemicolon(t *testing.T) {
+	raw := "MATH 152 with a minimum grade of C; or MATH 155 or MATH 158, with a grade of at least B."
+	got := Parse(raw)
+	if got.Type != "or" {
+		t.Fatalf("expected root type 'or', got %q: %v", got.Type, got)
+	}
+}
+
+func TestParseOrOfCourses(t *testing.T) {
+	got := Parse("ARCH 101 or ARCH 201")
+	if got.Type != "or" {
+		t.Fatalf("expected type 'or', got %q", got.Type)
+	}
+	if len(got.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(got.Children))
+	}
+}
+
+func TestParseUnitsWithCourses(t *testing.T) {
+	got := Parse("60 units, including either HSCI 130 or BPK 140, with a minimum grade of C-")
+	if got == nil {
+		t.Fatal("expected non-nil node")
+	}
+}
+
+func TestParseBareUnits(t *testing.T) {
+	got := Parse("30 units")
+	if got == nil {
+		t.Fatal("expected non-nil node")
+	}
+	if got.Type != "course" || got.ID != "UNITS:30" {
+		t.Errorf("got %v, want course(UNITS:30)", got)
+	}
+}

--- a/internal/store/outlines.go
+++ b/internal/store/outlines.go
@@ -10,11 +10,13 @@ import (
 	"time"
 
 	. "github.com/brianrahadi/sfucourses-api/internal/model"
+	"github.com/brianrahadi/sfucourses-api/internal/prereq"
 	"github.com/samber/lo"
 )
 
 type OutlineStore struct {
 	cachedOutlines []CourseOutline
+	parsedPrereqs  PrereqMap
 	lastLoaded     time.Time
 	mu             sync.RWMutex
 	filePath       string
@@ -49,6 +51,7 @@ func (s *OutlineStore) loadOutlines() error {
 
 	s.mu.Lock()
 	s.cachedOutlines = outlines
+	s.parsedPrereqs = prereq.ParseAll(outlines)
 	s.lastLoaded = time.Now()
 	s.mu.Unlock()
 
@@ -98,4 +101,10 @@ func (s *OutlineStore) Get(ctx context.Context, dept, number string) ([]CourseOu
 	}
 
 	return nil, ErrNotFound
+}
+
+func (s *OutlineStore) GetPrereqMap() PrereqMap {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.parsedPrereqs
 }

--- a/internal/store/storage.go
+++ b/internal/store/storage.go
@@ -15,6 +15,7 @@ var (
 type Storage struct {
 	Outlines interface {
 		Get(context.Context, string, string) ([]model.CourseOutline, error)
+		GetPrereqMap() model.PrereqMap
 		ForceReload() error
 	}
 


### PR DESCRIPTION
feat: Add parsed prerequisite API endpoint

Root Cause:
  - Raw prerequisite strings from SFU are unstructured strings

Fixes:
  - Added PrereqNode type (course/and/or nodes) and PrereqMap
  - Built tokenizer + recursive descent parser for SFU prereq strings
    handling nested parens, AND/OR, commas, semicolons, grade stripping,
    shorthand dept refs, and special tokens (UNITS, PERMISSION, COREQUISITE)
  - Added pruning to drop unparseable text (prose, high school refs)
  - Pre-computes PrereqMap at startup in OutlineStore
  - New endpoint GET /v1/rest/prerequisites with dept/number filtering
  - Added ?prereqs=true query param to GET /v1/rest/outlines
  - Added CI workflow (tests + Docker build)

Testing:
  - 22 parser unit tests with [CI run](https://github.com/Andy-J-B/sfucourses-api/actions/runs/29798085993)
  - Tested api endpoints with docker container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `GET /v1/rest/prerequisites` with optional `dept` and `number` filters.
  * Enhanced `GET /v1/rest/outlines` with a `prereqs` option to include parsed prerequisite expression trees, plus `short`/`SHORT` output controls.
  * Improved performance by caching parsed prerequisites for outline requests.
* **API Contract Updates**
  * Review fields `rating`, `difficulty`, `helpful`, and `not_helpful` are now returned as strings.
* **Tests**
  * Added comprehensive prerequisite parsing tests.
* **Chores**
  * Added CI workflow for Go tests and Docker builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->